### PR TITLE
Fix skipping onSwipeEnd and onSwipeCancel if not initialized

### DIFF
--- a/lib/flutter_swipable.dart
+++ b/lib/flutter_swipable.dart
@@ -180,13 +180,12 @@ class SwipableState extends State<Swipable> {
       newX = potentialX;
       newY = potentialY;
 
-      widget.onSwipeEnd!(currentPosition, details);
-    
+      widget.onSwipeEnd?.call(currentPosition, details);
     } else {
       newX = 0;
       newY = 0;
 
-      widget.onSwipeCancel!(currentPosition, details);
+      widget.onSwipeCancel?.call(currentPosition, details);
     }
   
     setState(() {


### PR DESCRIPTION
If user doesn't initialize onSwipeEnd and onSwipeCancel callbacks, there is a null error and code stops in line 183 or 188. Component is just relocated and swip doesn't work. Simple null check, makes it better.